### PR TITLE
Fix link to Environment set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Features:
 
 **This is a one time setup - skip this if you already have a working Docksal environment.**  
 
-Follow [Docksal environment setup instructions](https://github.com/docksal/docksal/blob/master/docs/docksal-env-setup.md)
+Follow [Docksal environment setup instructions](https://github.com/docksal/docksal/blob/develop/docs/env-setup.md)
    
 ### Step #2: Project setup
 


### PR DESCRIPTION
There is a broken link in documentation on homepage. https://monosnap.com/file/UbCCpQ8m142WwBDtvqGunZn6CLYpeQ
